### PR TITLE
Fix texture atlas gaps between tiles

### DIFF
--- a/map.py
+++ b/map.py
@@ -24,10 +24,11 @@ class Tile:
         self.y = y
         self.size = size
         self.texture = texture
+        # Use integer positions to avoid floating point issues
         self.sprite = pyglet.sprite.Sprite(
             img=texture,
-            x=x * size,
-            y=y * size,
+            x=int(x * size),
+            y=int(y * size),
             batch=batch
         )
         print(f"({self.sprite.x}, {self.sprite.y}) {texture.width}x{texture.height}")
@@ -48,7 +49,10 @@ class Map(pyglet.event.EventDispatcher):
         self.window.push_handlers(self)
         self.window.push_handlers(self.keys)
         pyglet.clock.schedule_interval(self.update, 1/30.0)
-        self.window.view = math.Mat4.from_scale(math.Vec3(self.zoom, self.zoom, 1)) @ math.Mat4.from_translation(math.Vec3(-self.offset.x, -self.offset.y, 0))
+        # Round offset to prevent subpixel positioning
+        rounded_x = round(self.offset.x)
+        rounded_y = round(self.offset.y)
+        self.window.view = math.Mat4.from_scale(math.Vec3(self.zoom, self.zoom, 1)) @ math.Mat4.from_translation(math.Vec3(-rounded_x, -rounded_y, 0))
         self.load_map()
         
 
@@ -70,7 +74,10 @@ class Map(pyglet.event.EventDispatcher):
         elif scroll_y < 0 and self.zoom > 0.2:
             self.zoom -= 1
 
-        self.window.view = math.Mat4.from_scale(math.Vec3(self.zoom, self.zoom, 1)) @ math.Mat4.from_translation(math.Vec3(-self.offset.x, -self.offset.y, 0))
+        # Round offset to prevent subpixel positioning
+        rounded_x = round(self.offset.x)
+        rounded_y = round(self.offset.y)
+        self.window.view = math.Mat4.from_scale(math.Vec3(self.zoom, self.zoom, 1)) @ math.Mat4.from_translation(math.Vec3(-rounded_x, -rounded_y, 0))
        
 
     def update(self, dt):
@@ -92,9 +99,15 @@ class Map(pyglet.event.EventDispatcher):
         if moved:
             offset = offset.normalize() * 10
             self.offset = self.offset + offset
-            self.window.view = math.Mat4.from_scale(math.Vec3(self.zoom, self.zoom, 1)) @ math.Mat4.from_translation(math.Vec3(-self.offset.x, -self.offset.y, 0))
+            # Round offset to prevent subpixel positioning
+            rounded_x = round(self.offset.x)
+            rounded_y = round(self.offset.y)
+            self.window.view = math.Mat4.from_scale(math.Vec3(self.zoom, self.zoom, 1)) @ math.Mat4.from_translation(math.Vec3(-rounded_x, -rounded_y, 0))
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
         if buttons & pyglet.window.mouse.RIGHT:
             self.offset = self.offset + math.Vec2(dx, dy)
-            self.window.view = math.Mat4.from_scale(math.Vec3(self.zoom, self.zoom, 1)) @ math.Mat4.from_translation(math.Vec3(-self.offset.x, -self.offset.y, 0))
+            # Round offset to prevent subpixel positioning
+            rounded_x = round(self.offset.x)
+            rounded_y = round(self.offset.y)
+            self.window.view = math.Mat4.from_scale(math.Vec3(self.zoom, self.zoom, 1)) @ math.Mat4.from_translation(math.Vec3(-rounded_x, -rounded_y, 0))

--- a/tileset.py
+++ b/tileset.py
@@ -15,6 +15,7 @@
 
 import json
 import pyglet
+from pyglet.gl import *
 
 class TileSet:
     def __init__(self):
@@ -25,12 +26,27 @@ class TileSet:
 
         self.tilesize = self.tiles['tile_size']
 
+        # Create a custom texture atlas with border padding
+        atlas = pyglet.image.atlas.TextureAtlas(512, 512)
+        
+        # Apply texture parameters to the atlas texture
+        glBindTexture(atlas.texture.target, atlas.texture.id)
+        glTexParameteri(atlas.texture.target, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
+        glTexParameteri(atlas.texture.target, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
+        glTexParameteri(atlas.texture.target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+        glTexParameteri(atlas.texture.target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
+        
         for tile in self.tiles['tiles']:
             tile_name = tile['name']
             texture_path = tile['texture']
-            tile_image = pyglet.resource.image(texture_path)
+            # Load image without auto-atlas
+            tile_image = pyglet.resource.image(texture_path, atlas=False)
             print(f"{tile_image.width}x{tile_image.height} {tile_name} {texture_path}")
-            self.tile_images[tile_name] = tile_image
+            # Convert texture to image data for atlas
+            image_data = tile_image.get_image_data()
+            # Add to our atlas with 1-pixel border
+            tile_region = atlas.add(image_data, border=1)
+            self.tile_images[tile_name] = tile_region
 
     def __getitem__(self, tile_name):
         if tile_name in self.tile_images:


### PR DESCRIPTION
- Create custom texture atlas with 1-pixel border padding
- Apply GL_NEAREST filtering to atlas texture
- Use integer positions for tile sprites
- Round camera offsets to prevent subpixel positioning

This fixes the visual gaps that appear between tiles when using Pyglet's automatic texture atlas feature.

🤖 Generated with [Claude Code](https://claude.ai/code)